### PR TITLE
Support for 5.3 operators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <name>lua-parser</name>
 
   <properties>
-    <antlr3.version>3.5</antlr3.version>
+    <antlr3.version>3.5.2</antlr3.version>
   </properties>
 
   <dependencies>

--- a/src/main/antlr3/nl/bigo/luaparser/Lua52Walker.g
+++ b/src/main/antlr3/nl/bigo/luaparser/Lua52Walker.g
@@ -115,16 +115,23 @@ expr
  | ^(GTEq a=expr b=expr)
  | ^(NEq a=expr b=expr)
  | ^(Eq a=expr b=expr)
+ | ^(BitOr a=expr b=expr)
+ | ^(Tilde a=expr b=expr) // bitwise exclusive OR
+ | ^(BitAnd a=expr b=expr)
+ | ^(BitRShift a=expr b=expr)
+ | ^(BitLShift a=expr b=expr)
  | ^(DotDot a=expr b=expr)
  | ^(Add a=expr b=expr)
  | ^(Minus a=expr b=expr)
  | ^(Mult a=expr b=expr)
  | ^(Div a=expr b=expr)
+ | ^(FloorDiv a=expr b=expr)
  | ^(Mod a=expr b=expr)
  | ^(Pow a=expr b=expr)
  | ^(UNARY_MINUS a=expr)
  | ^(Length a=expr)
  | ^(Not a=expr)
+ | ^(BIT_NOT a=expr)
  | Name
  | DotDotDot
  | Number


### PR DESCRIPTION
Parsing `assignments = ~x, x | y, x & y, x ~ y, x >> 2, x << 2, x // 2` results in the following parse tree:

```
'- CHUNK
   '- ASSIGNMENT
      |- VAR_LIST
      |  '- Name='assignments'
      '- EXPR_LIST
         |- BIT_NOT
         |  '- Name='x'
         |- BitOr='|'
         |  |- Name='x'
         |  '- Name='y'
         |- BitAnd='&'
         |  |- Name='x'
         |  '- Name='y'
         |- Tilde='~'
         |  |- Name='x'
         |  '- Name='y'
         |- BitRShift='>>'
         |  |- Name='x'
         |  '- Number='2'
         |- BitLShift='<<'
         |  |- Name='x'
         |  '- Number='2'
         '- FloorDiv='//'
            |- Name='x'
            '- Number='2'
```